### PR TITLE
Fix nesting bug

### DIFF
--- a/design/craft/inclusivecache/src/MSHR.scala
+++ b/design/craft/inclusivecache/src/MSHR.scala
@@ -189,6 +189,8 @@ class MSHR(params: InclusiveCacheParameters) extends Module
     val nestedwb  = new NestedWriteback(params).flip
     val mshr_id   = Input(UInt())
     val prefetcherAcquire = Valid(new PrefetcherAcquire(params.inner.bundle.addressBits))
+
+    val issueMeta = Valid(new DirectoryWrite(params)).flip
   }
 
   when (io.allocate.valid) {
@@ -1102,5 +1104,13 @@ class MSHR(params: InclusiveCacheParameters) extends Module
         s_writeback := Bool(false)
       }
     }
+  }
+
+  when (io.status.valid && io.issueMeta.valid) {
+    DebugPrint(params, s"MSHR %d: update forwarding meta\n", io.mshr_id)
+    meta.dump()
+    DebugPrint(params, "=================")
+    io.issueMeta.bits.dump()
+    meta := io.issueMeta.bits.data
   }
 }


### PR DESCRIPTION
Nesting: allowing requests on the same address allocated in
bc_mshr or c_mshr to avoid deadlock.

Problem: different mshrs read the same old directory entry,
breaking its consistency.

Solution (not so solid):
1. the scheduled mshr directory updating forwards to c_mshr.
2. forbid c_mshr insertion on the selecting cycle which has
need-to-scheudle mshrs, avoid a RAW hazard.